### PR TITLE
ci: add build workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      # Placeholder values only. The production build constructs API clients
+      # (which validate that a key is *present*) but never makes real calls at
+      # build time, so these dummies are enough to compile. Real secrets live in
+      # the deploy environment, not in CI.
+      OPENAI_API_KEY: sk-ci-placeholder
+      TYPESENSE_HOST: dummy.typesense.net
+      TYPESENSE_API_KEY: dummy
+      NEXT_PUBLIC_TYPESENSE_HOST: dummy.typesense.net
+      NEXT_PUBLIC_TYPESENSE_API_SEARCH_ONLY: dummy
+      CLOUDFLARE_IMAGES_ID: dummy
+      NEXT_PUBLIC_CLOUDFLARE_IMAGES_ID: dummy
+      NEXT_PUBLIC_UMAMI_WEBSITE_ID: dummy
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - name: Build
+        run: npx next build


### PR DESCRIPTION
Adds `.github/workflows/ci.yml` — the repo had no CI (MISSING_CI on the fleet repo-scan).

**On push to main + every PR:**
- `npm ci` — install + lockfile integrity
- `next build` — full production compile gate

Build-time env vars are **placeholders** (`OPENAI_API_KEY: sk-ci-placeholder`, dummy Typesense/Cloudflare/Umami). The build only *constructs* the OpenAI/Typesense clients (which validate that a key is present) and never makes a real call at build time, so no live secrets are needed in CI — real ones stay in the deploy env.

Why build and not lint: `next lint` is removed in Next 16, and running ESLint directly flags 4 `react-hooks/set-state-in-effect` cases that are intentional `useEffect` random-init (kept in an effect specifically to avoid SSR hydration mismatch). So the build is the honest green gate. Verified locally against current `main` — `next build` exits 0 with the placeholder env.